### PR TITLE
fix tests

### DIFF
--- a/tests/test_arithmetic_shift_left.py
+++ b/tests/test_arithmetic_shift_left.py
@@ -400,7 +400,10 @@ py_only_errs = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_arithmetic_shift_right.py
+++ b/tests/test_arithmetic_shift_right.py
@@ -400,7 +400,10 @@ py_only_errs = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_binaryop_add.py
+++ b/tests/test_binaryop_add.py
@@ -364,7 +364,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_binaryop_div.py
+++ b/tests/test_binaryop_div.py
@@ -341,7 +341,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_binaryop_modulo.py
+++ b/tests/test_binaryop_modulo.py
@@ -387,7 +387,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_binaryop_mult.py
+++ b/tests/test_binaryop_mult.py
@@ -341,7 +341,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_binaryop_pow.py
+++ b/tests/test_binaryop_pow.py
@@ -324,7 +324,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_binaryop_sub.py
+++ b/tests/test_binaryop_sub.py
@@ -353,7 +353,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_bitwise_and.py
+++ b/tests/test_bitwise_and.py
@@ -337,7 +337,10 @@ py_only_errs = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_bitwise_or.py
+++ b/tests/test_bitwise_or.py
@@ -337,7 +337,10 @@ py_only_errs = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_bitwise_xor.py
+++ b/tests/test_bitwise_xor.py
@@ -337,7 +337,10 @@ py_only_errs = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_builtin_math_functions.py
+++ b/tests/test_builtin_math_functions.py
@@ -455,7 +455,7 @@ run_tests = [
     (log2_double, (), 10),
     (max_double, (), 2048),
     (min_double, (), 1024),
-    (mod_double, (), -2),
+    (mod_double, (), 1.0),
     (pow_double, (), 27),
     (round_double, (), 4),
     (sin_double, (), 1),
@@ -478,11 +478,15 @@ transform_tests = run_tests + [
 
 py_only_different_behavior_tests = [
     (abs_variable_boolean, (), False),
+    (mod_double, (), 1.0),
 ]
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", transform_tests, ids=idfunc)

--- a/tests/test_builtin_veristand_functions.py
+++ b/tests/test_builtin_veristand_functions.py
@@ -204,7 +204,10 @@ run_as_rts_tests = run_everywhere_tests + [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_compare_equal.py
+++ b/tests/test_compare_equal.py
@@ -329,7 +329,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_compare_greater.py
+++ b/tests/test_compare_greater.py
@@ -278,7 +278,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_compare_greater_equal.py
+++ b/tests/test_compare_greater_equal.py
@@ -539,7 +539,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_compare_inequality.py
+++ b/tests/test_compare_inequality.py
@@ -328,7 +328,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_compare_less.py
+++ b/tests/test_compare_less.py
@@ -278,7 +278,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_compare_less_equal.py
+++ b/tests/test_compare_less_equal.py
@@ -539,7 +539,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -306,7 +306,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", transform_tests, ids=idfunc)

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -717,7 +717,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params", transform_tests, ids=idfunc)

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -102,7 +102,10 @@ transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", transform_tests, ids=idfunc)

--- a/tests/test_for_loop.py
+++ b/tests/test_for_loop.py
@@ -232,7 +232,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_generate_error.py
+++ b/tests/test_generate_error.py
@@ -266,7 +266,10 @@ run_as_rts_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 def test_gen_continue_no_fail():

--- a/tests/test_ifexpression.py
+++ b/tests/test_ifexpression.py
@@ -183,7 +183,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_logical_and.py
+++ b/tests/test_logical_and.py
@@ -174,7 +174,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_logical_not.py
+++ b/tests/test_logical_not.py
@@ -158,7 +158,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_logical_or.py
+++ b/tests/test_logical_or.py
@@ -166,7 +166,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_multitask.py
+++ b/tests/test_multitask.py
@@ -440,7 +440,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_runpyasrtseq.py
+++ b/tests/test_runpyasrtseq.py
@@ -72,7 +72,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_stop_taks.py
+++ b/tests/test_stop_taks.py
@@ -161,7 +161,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_subroutine_call.py
+++ b/tests/test_subroutine_call.py
@@ -387,7 +387,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_subscript.py
+++ b/tests/test_subscript.py
@@ -118,7 +118,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -200,7 +200,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_try_finally.py
+++ b/tests/test_try_finally.py
@@ -241,7 +241,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_unary_invert.py
+++ b/tests/test_unary_invert.py
@@ -300,7 +300,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)

--- a/tests/test_while.py
+++ b/tests/test_while.py
@@ -215,7 +215,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", transform_tests, ids=idfunc)

--- a/tests/test_yield.py
+++ b/tests/test_yield.py
@@ -90,7 +90,10 @@ fail_transform_tests = [
 
 
 def idfunc(val):
-    return val.__name__
+    try:
+        return val.__name__
+    except AttributeError:
+        return str(val)
 
 
 @pytest.mark.parametrize("func_name, params, expected_result", run_tests, ids=idfunc)


### PR DESCRIPTION
- fallback in the ids callback when a parameter does not have a "__name__" attribute. pytest calls ids callback for all the parameters of a parametrized test and tuples do not have the "__name__" attribute.
- fix the expected result of some modulo tests after changes in behavior of VeriStand 2018sp1