### PR TITLE
Fix flake8 junit report generation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,8 @@ deps =
     flake8-import-order>=0.9
     flake8-junit-report
 commands =
-    flake8 src/niveristand/ tests/ examples/ setup.py --exclude tests/legacy --output-file {envlogdir}/{envname}.txt --tee
-    junit_conversor {envlogdir}/{envname}.txt {envlogdir}/junit-{envname}.xml
+    - flake8 src/niveristand/ tests/ examples/ setup.py --exclude tests/legacy --output-file {envlogdir}/{envname}.txt --tee
+    flake8_junit {envlogdir}/{envname}.txt {envlogdir}/junit-{envname}.xml
 
 [pytest]
 norecursedirs = .git examples docs dist tests/legacy


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Fix junit report generation by
 - Ignore status code returned from flake8, otherwise the second command will be skipped
 - Change junit_conversor to its proper name: flake8_junit

### Why should this Pull Request be merged?

junit report generation from flake8 is not working.

### What testing has been done?

Ran command, verified xml got generated.
