### PR TITLE
Use _internal for getting binaries path in tests.

### DIFF
--- a/tests/testutilities/configutilities.py
+++ b/tests/testutilities/configutilities.py
@@ -3,7 +3,8 @@ import json
 
 
 def getbinariesfolder():
-    return _getdevconfig()['BaseBinariesPath']
+    from niveristand import _internal
+    return _internal.base_assembly_path()
 
 
 def _getdevconfig():


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change configutilities used for tests so that it uses the same mechanism as the code in src to find the binaries folder.

### Why should this Pull Request be merged?

Tox can no be successfully run on a machine that only has Veristand installed but not a developer setup. After this change, the tests can be run in that scenario.

### What testing has been done?

Ran tox in both developer and installed setups.