### PR TITLE
Add an expected failure test for ChannelReference on vector channel

### DIFF
--- a/tests/test_channel_refs.py
+++ b/tests/test_channel_refs.py
@@ -1,4 +1,4 @@
-from niveristand import errors
+from niveristand import errors, realtimesequencetools
 from niveristand.clientapi import RealTimeSequence
 import pytest
 from testutilities import rtseqrunner, testfunctions
@@ -75,6 +75,10 @@ def test_channel_ref_array_return():
     with pytest.raises(errors.TranslateError):
         RealTimeSequence(testfunc)
 
+
+def test_channel_ref_for_vector_channel():
+    with pytest.raises(errors.VeristandError):
+        realtimesequencetools.run_py_as_rtseq(testfunctions.channel_ref_for_vector_channel)
 
 @pytest.mark.skip
 def test_channel_ref_array_run():

--- a/tests/testutilities/testfunctions.py
+++ b/tests/testutilities/testfunctions.py
@@ -189,6 +189,12 @@ def channel_ref_array_return():
 
 
 @_decorators.nivs_rt_sequence
+def channel_ref_for_vector_channel():
+    a = ChannelReference('Targets/Controller/Simulation Models/Models/Engine Demo/Parameters/a')
+    a.value = 50
+
+
+@_decorators.nivs_rt_sequence
 def channel_ref_array_validate_getter():
     a = VectorChannelReference("Targets/Controller/Simulation Models/Models/Engine Demo/Parameters/a")
     a[3].value = 5.0


### PR DESCRIPTION

[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a test for a case that was missing. Trying to run a sequence that creates a ChannelReference for a vector channel should throw an error during compile.

### Why should this Pull Request be merged?

Improves the robustness of the product. As VectorChannelReference support is expanded we'll need to make sure we don't break other use cases. 

### What testing has been done?

Tox
