### PR TITLE
Fix documentation generation.

### DIFF
--- a/src/niveristand/_internal.py
+++ b/src/niveristand/_internal.py
@@ -57,14 +57,12 @@ try:
     clr.AddReference("NationalInstruments.VeriStand.ClientAPI")
 except FileNotFoundException:
     try:
-        clr.AddReference(os.path.join(base_assembly_path(),
-                                      "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi.dll"))
-        clr.AddReference(os.path.join(base_assembly_path(),
-                                      "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities.dll"))
-        clr.AddReference(os.path.join(base_assembly_path(),
-                                      "NationalInstruments.VeriStand.DataTypes.dll"))
-        clr.AddReference(os.path.join(base_assembly_path(),
-                                      "NationalInstruments.VeriStand.ClientAPI.dll"))
+        from sys import path
+        path.append(base_assembly_path())
+        clr.AddReference("NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi")
+        clr.AddReference("NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities")
+        clr.AddReference("NationalInstruments.VeriStand.DataTypes")
+        clr.AddReference("NationalInstruments.VeriStand.ClientAPI")
     except FileNotFoundException as e:
         raise IOError(e.Message)
 

--- a/src/niveristand/clientapi/_factory.py
+++ b/src/niveristand/clientapi/_factory.py
@@ -99,7 +99,7 @@ class _DefaultGatewayFactory(object):
     """
 
     _default_gateway_ip_address = ""
-    _default_workspace = _Factory().get_workspace2("")
+    _default_workspace = None
 
     @classmethod
     def set_default_gateway_ip_address(cls, gateway_ip_address):
@@ -161,4 +161,6 @@ class _DefaultGatewayFactory(object):
             niveristand.clientapi._workspace2._Workspace2: A Workspace2 instance.
 
         """
+        if cls._default_workspace is None:
+            cls._default_workspace = _Factory().get_workspace2("")
         return cls._default_workspace

--- a/src/niveristand/clientapi/_stimulusprofilesession.py
+++ b/src/niveristand/clientapi/_stimulusprofilesession.py
@@ -1,9 +1,11 @@
 from niveristand import _errormessages, errors
 from niveristand.clientapi._dotnetclasswrapperbase import _DotNetClassWrapperBase
 from niveristand.clientapi._error import _Error
+from niveristand import _internal
 from NationalInstruments.VeriStand.ClientAPI import ISequenceControl as ISequenceControlDotNet  # noqa: I100
 from NationalInstruments.VeriStand.ClientAPI import IStimulusProfileSession as IStimulusProfileSessionDotNet
 
+_internal.dummy()
 
 class _StimulusProfileSession(_DotNetClassWrapperBase):
     """


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Documentation was broken because import of _stimulusprofilesession
threw exceptions. Lazy load the gateway connection to avoid exceptions
when a connection is not needed.

### Why should this Pull Request be merged?

It fixes the documentation.

### What testing has been done?

Ran tox py35 and flake8
