### PR TITLE
Fixes LaunchNIVeriStand issue #36

### DIFF
--- a/src/niveristand/legacy/NIVeriStand.py
+++ b/src/niveristand/legacy/NIVeriStand.py
@@ -36,7 +36,7 @@ warnings.warn("NIVeriStand.py module is deprecated. "
 def LaunchNIVeriStand():
     """Launch NI VeriStand.exe from the installed location."""
     import subprocess
-    path = _internal.base_assembly_path()
+    path = _internal._get_install_path()
     # Try launching VeriStand with both the old and new .exe names.
     veristand = os.path.join(path, "NI VeriStand.exe")
     try:


### PR DESCRIPTION
Changed the LaunchNIVeriStand function by using _get_install_path() instead of base_assembly_path(). This results in the LaunchNIVeriStand function generating a path to the veristand.exe that is installed on the user's computer by looking through the user's registry key instead of a path that had additional folders appended to it that result in an error.

[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes issue #36 where NI VeriStand does not launch when calling the LaunchNIVeriStand function in the legacy API.

### Why should this Pull Request be merged?

In order to allow users to launch NI VeriStand using the legacy function.

### What testing has been done?

I tested the function and the NI VeriStand exe launches without any issues. It does not affect any test negatively either.
