### PR TITLE
Fix LaunchNIVeriStand and example

### DIFF
--- a/examples/legacy_mix.py
+++ b/examples/legacy_mix.py
@@ -9,12 +9,13 @@ def mix_legacy_and_rtseq_run():
     """Combines the legacy API with Python real-time sequences to run a deterministic test."""
     # Ensures NI VeriStand is running.
     NIVeriStand.LaunchNIVeriStand()
+    NIVeriStand.WaitForNIVeriStandReady()
     # Uses the ClientAPI interface to get a reference to Workspace2
     workspace = NIVeriStand.Workspace2("localhost")
-    engine_demo_path = os.path.join(os.path.expanduser("~"), 'Documents', 'National Instruments', 'VeriStand 2018',
+    engine_demo_path = os.path.join(os.path.expanduser("~public"), 'Documents', 'National Instruments', 'NI VeriStand 2019',
                                     'Examples', 'Stimulus Profile', 'Engine Demo', 'Engine Demo.nivssdf')
     # Deploys the system definition.
-    workspace.ConnectToSystem(engine_demo_path, True, 60000)
+    workspace.ConnectToSystem(engine_demo_path, True, 120000)
     try:
         # Uses Python real-time sequences to run a test.
         run_py_as_rtseq(run_engine_demo)

--- a/examples/legacy_mix.py
+++ b/examples/legacy_mix.py
@@ -12,8 +12,9 @@ def mix_legacy_and_rtseq_run():
     NIVeriStand.WaitForNIVeriStandReady()
     # Uses the ClientAPI interface to get a reference to Workspace2
     workspace = NIVeriStand.Workspace2("localhost")
-    engine_demo_path = os.path.join(os.path.expanduser("~public"), 'Documents', 'National Instruments', 'NI VeriStand 2019',
-                                    'Examples', 'Stimulus Profile', 'Engine Demo', 'Engine Demo.nivssdf')
+    engine_demo_path = os.path.join(os.path.expanduser("~public"), 'Documents', 'National Instruments',
+                                    'NI VeriStand 2019', 'Examples', 'Stimulus Profile', 'Engine Demo',
+                                    'Engine Demo.nivssdf')
     # Deploys the system definition.
     workspace.ConnectToSystem(engine_demo_path, True, 120000)
     try:

--- a/src/niveristand/_internal.py
+++ b/src/niveristand/_internal.py
@@ -9,14 +9,9 @@ def base_assembly_path():
     except (IOError, KeyError):
         pass
     try:
-        return _get_ref_assemblies_path()
+        return _get_install_path()
     except IOError:
         return ''
-
-
-def _get_ref_assemblies_path():
-    latest_dir = _get_install_path()
-    return os.path.join(latest_dir, 'nivs.lib', 'Reference Assemblies')
 
 
 def _get_install_path():

--- a/src/niveristand/legacy/NIVeriStand.py
+++ b/src/niveristand/legacy/NIVeriStand.py
@@ -37,18 +37,28 @@ def LaunchNIVeriStand():
     """Launch NI VeriStand.exe from the installed location."""
     import subprocess
     path = _internal.base_assembly_path()
-    # Try launching VeriStand with both the old and new .exe names.
-    veristand = os.path.join(path, "NI VeriStand.exe")
+    # Try launching VeriStand with new .exe name.
     try:
+        veristand = os.path.join(path, "VeriStand Project Explorer.exe")
         subprocess.Popen([veristand, ""]).pid
         print(veristand)
     except OSError:
+        raise NIVeriStandException(-307652, "Could not launch VeriStand.")
+
+
+def WaitForNIVeriStandReady(address="localhost", secondsTimeout=120):
+    import time
+
+    start = time.time()
+    while True:
         try:
-            veristand = os.path.join(path, "VeriStand Project Explorer.exe")
-            subprocess.Popen([veristand, ""]).pid
-            print(veristand)
-        except OSError:
-            raise NIVeriStandException(-307652, "Could not launch VeriStand.")
+            Factory().GetIWorkspace2(address)
+            break
+        except Exception:
+            time.sleep(0.5)
+            now = time.time()
+            if (now - start) > secondsTimeout:
+                raise NIVeriStandException(-307663, "Could not connect to gateway process.")
 
 
 def _ConvertMATRIXTO1DARRVAL_(values):

--- a/src/niveristand/legacy/NIVeriStand.py
+++ b/src/niveristand/legacy/NIVeriStand.py
@@ -58,7 +58,7 @@ def WaitForNIVeriStandReady(address="localhost", secondsTimeout=120):
             time.sleep(0.5)
             now = time.time()
             if (now - start) > secondsTimeout:
-                raise NIVeriStandException(-307663, "Could not connect to gateway process.")
+                raise NIVeriStandException(-307663, "Could not connect to gateway.")
 
 
 def _ConvertMATRIXTO1DARRVAL_(values):


### PR DESCRIPTION
[ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

LaunchNIVeriStand does not work with VeriStand >= 2019. Wrong path is being used.

This PR will fix that and also make the example run with success.

Fixes issue #36 where NI VeriStand does not launch when calling the LaunchNIVeriStand function in the legacy API.

### Why should this Pull Request be merged?

Fixes a bug

### What testing has been done?

The exampled passed with success using VeriStand 2021
