### PR TITLE
Updated legacy API

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,15 @@
-[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).
+[ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).
+
+TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).
 
 ### What does this Pull Request accomplish?
 
-This pull Request updates legacy API, Worskpace2 class with the missing ReconnectToSystem function along with the basic use example.
-It also fixes the GetSystemState function - it stopped working due to the PythonNET update.
+TODO: Include high-level description of the changes in this pull request.
 
 ### Why should this Pull Request be merged?
 
-This Pull Request adds missing and useful feature and fixes bug.
+TODO: Justify why this contribution should be part of the project.
 
 ### What testing has been done?
 
-ReconnectToSystemTest was prepared and is included in the Pull Request. It uses project SineWave Delay which is being shipped along
-with the VeriStand 2020. It was tested using VeriStand 2020 and it's working properly.
-ReconnnectToSystemTest also tests GetSystemState function.
+TODO: Detail what testing has been done to ensure this submission meets requirements.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,16 @@
-[ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).
-
-TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).
+[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).
 
 ### What does this Pull Request accomplish?
 
-TODO: Include high-level description of the changes in this pull request.
+This pull Request updates legacy API, Worskpace2 class with the missing ReconnectToSystem function along with the basic use example.
+It also fixes the GetSystemState function - it stopped working due to the PythonNET update.
 
 ### Why should this Pull Request be merged?
 
-TODO: Justify why this contribution should be part of the project.
+This Pull Request adds missing and useful feature and fixes bug.
 
 ### What testing has been done?
 
-TODO: Detail what testing has been done to ensure this submission meets requirements.
+ReconnectToSystemTest was prepared and is included in the Pull Request. It uses project SineWave Delay which is being shipped along
+with the VeriStand 2020. It was tested using VeriStand 2020 and it's working properly.
+ReconnnectToSystemTest also tests GetSystemState function.

--- a/examples/legacy_basic_reconnect.py
+++ b/examples/legacy_basic_reconnect.py
@@ -1,0 +1,58 @@
+import sys
+import time
+from niveristand.errors import RunError
+from niveristand.legacy import NIVeriStand
+
+# This is an example script to demonstrate the usage of NIVeriStand Python API.
+# This script requires Python 32b(tested on Python 3.9.6) and NIVeriStand Python API.
+# It can be downloaded here: https://niveristand-python.readthedocs.io/en/latest/index.html
+
+# This script deploys example project on the selected GATEWAY and it prints two channel values every 100ms
+# This script requires VeriStand serwer to be running. It is ran automatically after launching VeriStand.
+# You can also start it manually from the command line.
+# Default veristand-server.exe location:
+# "C:\Program Files (x86)\National Instruments\VeriStand 2020\veristand-server.exe"
+# Press Ctrl + C to stop the program.
+
+PROJECTDIR = r"C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Projects"
+SDF = PROJECTDIR + r"\Example\Sinewave Delay.nivssdf"
+
+GATEWAY = "localhost"  # GATEWAY address
+TARGET = "Controller"
+
+SINE_WAVE = 'Aliases/SineWave'
+LOOP_RATE = 'Targets/Controller/System Channels/Actual Loop Rate'
+# channel adresses can be entered as full paths or aliases
+
+
+def sleep():
+    time.sleep(0.1)
+
+
+wks = NIVeriStand.Workspace2(GATEWAY)  # create workspace object
+try:
+    # print("Running %s" % SDF)
+    # wks.ConnectToSystem(SDF,True,60000)  # connect to system, deploy project, 60s timeout
+    print("Connecting to the gateway %(gateway)s, target %(target)s" % {'gateway': GATEWAY, "target": TARGET})
+    wks.ReconnectToSystem(TARGET, True, None, 60000)  # reconnect to already deployed system
+    print("NI VeriStand Running and Client Connected!")
+    input("Press Enter to start printing data values, then you can press Ctrl+C to disconnect.")
+
+    while (1):
+        print("Actual Loop Rate: ", wks.GetSingleChannelValue(LOOP_RATE))
+        print("Sine wave:", wks.GetSingleChannelValue(SINE_WAVE))
+        print('')
+        sleep()
+
+except RunError as err:
+    TEST_COMMENT = "Unexpected Exception " + err.error.message()
+    print(TEST_COMMENT)
+    time.sleep(10)
+except KeyboardInterrupt:
+    print("Press any button to exit script.")
+except Exception:
+    print(sys.exc_info())
+    time.sleep(10)
+finally:
+    wks.DisconnectFromSystem('', True)  # undeploy project
+    # pass

--- a/examples/legacy_basic_reconnect.py
+++ b/examples/legacy_basic_reconnect.py
@@ -3,21 +3,15 @@ import time
 from niveristand.errors import RunError
 from niveristand.legacy import NIVeriStand
 
-# This is an example script to demonstrate the usage of NIVeriStand Python API.
-# This script requires Python 32b(tested on Python 3.9.6) and NIVeriStand Python API.
-# It can be downloaded here: https://niveristand-python.readthedocs.io/en/latest/index.html
+# This is an example script to demonstrate the usage of ReconnectToSystem function.
+# This script requires cPython(tested on cPython 3.9.6) and (obviously) NIVeriStand Python API.
 
 # This script deploys example project on the selected GATEWAY and it prints two channel values every 100ms
-# This script requires VeriStand serwer to be running. It is ran automatically after launching VeriStand.
-# You can also start it manually from the command line.
-# Default veristand-server.exe location:
-# "C:\Program Files (x86)\National Instruments\VeriStand 2020\veristand-server.exe"
+# This script requires the example SineWave Delay Project(shipped with LabVIEW 2020) to be deployed.
+# SineWave Delay project file path: C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Projects\Example\Sinewave Delay.nivsproj
 # Press Ctrl + C to stop the program.
 
-PROJECTDIR = r"C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Projects"
-SDF = PROJECTDIR + r"\Example\Sinewave Delay.nivssdf"
-
-GATEWAY = "localhost"  # GATEWAY address
+GATEWAY = "localhost"
 TARGET = "Controller"
 
 SINE_WAVE = 'Aliases/SineWave'
@@ -31,8 +25,6 @@ def sleep():
 
 wks = NIVeriStand.Workspace2(GATEWAY)  # create workspace object
 try:
-    # print("Running %s" % SDF)
-    # wks.ConnectToSystem(SDF,True,60000)  # connect to system, deploy project, 60s timeout
     print("Connecting to the gateway %(gateway)s, target %(target)s" % {'gateway': GATEWAY, "target": TARGET})
     wks.ReconnectToSystem(TARGET, True, None, 60000)  # reconnect to already deployed system
     print("NI VeriStand Running and Client Connected!")
@@ -55,4 +47,3 @@ except Exception:
     time.sleep(10)
 finally:
     wks.DisconnectFromSystem('', True)  # undeploy project
-    # pass

--- a/src/niveristand/legacy/NIVeriStand.py
+++ b/src/niveristand/legacy/NIVeriStand.py
@@ -12,6 +12,7 @@ import warnings
 from niveristand import _internal
 import System  # noqa
 from NationalInstruments.VeriStand import DataArray  # noqa
+from NationalInstruments.VeriStand.ClientAPI import DeployOptions  # noqa
 from NationalInstruments.VeriStand.ClientAPI import Factory  # noqa
 from NationalInstruments.VeriStand.ClientAPI import SystemState  # noqa
 from NationalInstruments.VeriStand.ClientAPI import AlarmInfo  # noqa
@@ -337,7 +338,7 @@ class Workspace2(Workspace):
 
     def GetSystemState(self):
         """Returns the current state of the system."""
-        data = self.iwks.GetSystemState(0, "", None)
+        data = self.iwks.GetSystemState(SystemState(0), "", None)
         _RaiseException_(data[0])
         targets = []
         for target in data[3]:
@@ -349,6 +350,17 @@ class Workspace2(Workspace):
         """Connects the VeriStand Gateway to one or more targets running on the System Definition file you specify."""
         _RaiseException_(
             self.iwks.ConnectToSystem(systemdefinition_file, System.Boolean(deploy), System.UInt32(timeout)))
+
+    def ReconnectToSystem(self, target, deploy, calibration_file, timeout):
+        """Reconnects the VeriStand Gateway to a target within the system definition file used by the Gateway.\
+            You can also redeploy the system definition file."""
+        options = DeployOptions()
+        options.DeploySystemDefinition = System.Boolean(deploy)
+        options.Timeout = timeout
+        options.CalibratonFilePath = calibration_file
+
+        _RaiseException_(
+            self.iwks.ReconnectToSystem(System.String(target), options))
 
     def DisconnectFromSystem(self, password, undeploy_system_definition):
         """Disconnects the VeriStand Gateway from the targets."""

--- a/tests/legacy/ReconnectToSystemTest.py
+++ b/tests/legacy/ReconnectToSystemTest.py
@@ -1,0 +1,74 @@
+import pytest
+
+from niveristand.legacy import NIVeriStand
+from niveristand.legacy.NIVeriStand import NIVeriStandException
+from niveristand.errors import RunError
+
+PROJECTDIR = r"C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Projects"
+SDF = PROJECTDIR + r"\Example\Sinewave Delay.nivssdf"
+# Prior to running this test the SDF file above must be deployed
+
+GATEWAY = "localhost"
+TARGET = "Controller"
+SINE_WAVE = 'Aliases/SineWave'
+LOOP_RATE = 'Targets/Controller/System Channels/Actual Loop Rate'
+
+
+def sleep():
+    import time
+    time.sleep(1)
+
+
+TEST_RESULT = 0 #Testresult set to false in beginning
+TEST_COMMENT = "" #Test  comment to append to result
+TEST_ID = 124123
+
+def test_reconnect_to_system():
+    wks = NIVeriStand.Workspace2(GATEWAY)
+    print("")
+    print("Connecting to the gateway %(gateway)s, target %(target)s" % {'gateway': GATEWAY, "target": TARGET})
+    wks.ReconnectToSystem(TARGET, True, None, 60000)
+
+    try:
+
+        result = wks.GetSystemState()
+        assert(result['systemdefinition_file'] == SDF), "System definition file is not the same as deployed"
+
+        print("Get System Node Children")
+        result = wks.GetSystemNodeChildren(r"Controller/Simulation Models/Models/sinewave/Execution")
+        assert(len(result) == 4), "Model Exceution should return 4 node"
+
+        #test we can still get system node children with full path.
+        result = wks.GetSystemNodeChildren(r"Targets/Controller/Simulation Models/Models/sinewave/Execution")
+        assert(len(result) == 4), "Model Exceution should return 4 node"
+
+        print("Get System Node Channel List")
+        result = wks.GetSystemNodeChannelList('')
+        assert(len(result) >= 100), "At the very least we always have 100 channel"
+        print(result[2])
+
+        print("Get Alias List")
+        result = wks.GetAliasList()
+        assert(len(result) == 6), "Expected 6 aliases but get something different %d" % len(result)
+        assert(result['SineWave'] == r"Targets/Controller/Simulation Models/Models/sinewave/Signals/sine/SineWave"), "Alias for SineWave incorrect"
+
+        #Mix up different mode of how we look up system nodes data: full path and also relative to Targets Section.
+        nodes = (SINE_WAVE, LOOP_RATE)
+        result = wks.GetMultipleSystemNodesData(nodes)
+        assert(len(result) == 2), "Ask for 2 node info get no info"
+
+        print("Validating channels")
+        section = result[0]
+        print(section)
+        assert(section['isChannel'] == 1), "Expected channel, got something different."
+
+        testNode = result[1]
+        print(testNode)
+        assert(testNode['isChannel'] == 1), "Expected channel, got something different."
+
+        print("Test PASSED")
+        print("")
+
+    finally:
+        pass
+        wks.DisconnectFromSystem("", True)


### PR DESCRIPTION
Added ReconnectToSystem along with the use example and test, fixed GetSystemState.

[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This pull Request updates legacy API, Worskpace2 class with the missing ReconnectToSystem function along with the basic use example.
It also fixes the GetSystemState function - it stopped working due to the PythonNET update.

### Why should this Pull Request be merged?

This Pull Request adds missing and useful feature and fixes bug.

### What testing has been done?

ReconnectToSystemTest was prepared and is included in the Pull Request. It uses project SineWave Delay which is being shipped along with the VeriStand 2020. It was tested using VeriStand 2020 and it's working properly.
ReconnnectToSystemTest also tests GetSystemState function.
