### PR TITLE
Pin pythonnet to 2.5.2 or a compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-pythonnet
+pythonnet~=2.5.2
 tox
 pyyaml


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Pin `pythonnet` dependency to `2.5.2` or a later bugfix.

### Why should this Pull Request be merged?

We are not currently compatible with `pythonnet` `3.0.0`.

### What testing has been done?

Installed the new `requirements.txt` file in a venv and confirmed that `2.5.2` was chosen.
