### PR TITLE
update python API to support pythonnet 3.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-pythonnet~=2.5.2
+pythonnet~=3.0.1
 tox
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
-    install_requires=['pythonnet~=2.5.2', 'PyYAML'],
+    install_requires=['pythonnet~=3.0.1', 'PyYAML'],
     tests_require=['pytest', 'numpy'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/src/niveristand/clientapi/_datatypes/rtprimitives.py
+++ b/src/niveristand/clientapi/_datatypes/rtprimitives.py
@@ -469,7 +469,6 @@ class I32Value(DataType):
 
     def _to_data_value(self, value):
         if self._is_valid_assign_type(value):
-            print(value)
             value = SystemInt32(int(value))
         else:
             raise TypeError('%s can not be created from value "%s"' % (self.__class__.__name__, str(value)))

--- a/src/niveristand/clientapi/_datatypes/rtprimitives.py
+++ b/src/niveristand/clientapi/_datatypes/rtprimitives.py
@@ -389,7 +389,7 @@ class ChannelReference(DataType):
     def _to_data_value(self, value):
         # in pythonnet 3.0.0+, strings are no longer coerced to 0 by ClientApiDoubleValue
         if isinstance(value, str):
-            return 0
+            return ClientApiDoubleValue(0.0)
         else:
             return ClientApiDoubleValue(value)
 

--- a/src/niveristand/clientapi/_datatypes/rtprimitives.py
+++ b/src/niveristand/clientapi/_datatypes/rtprimitives.py
@@ -387,7 +387,11 @@ class ChannelReference(DataType):
         _DefaultGatewayFactory.get_workspace2().set_single_channel_value(self._channel_name, newvalue)
 
     def _to_data_value(self, value):
-        return ClientApiDoubleValue(value)
+        # in pythonnet 3.0.0+, strings are no longer coerced to 0 by ClientApiDoubleValue
+        if isinstance(value, str):
+            return 0
+        else:
+            return ClientApiDoubleValue(value)
 
 
 class VectorChannelReference(ArrayType):
@@ -465,7 +469,8 @@ class I32Value(DataType):
 
     def _to_data_value(self, value):
         if self._is_valid_assign_type(value):
-            value = SystemInt32(value)
+            print(value)
+            value = SystemInt32(int(value))
         else:
             raise TypeError('%s can not be created from value "%s"' % (self.__class__.__name__, str(value)))
         return ClientApiI32Value(value)
@@ -488,7 +493,7 @@ class I64Value(DataType):
 
     def _to_data_value(self, value):
         if self._is_valid_assign_type(value):
-            value = SystemInt64(value)
+            value = SystemInt64(int(value))
         else:
             raise TypeError('%s can not be created from value "%s"' % (self.__class__.__name__, str(value)))
         return ClientApiI64Value(value)
@@ -511,7 +516,7 @@ class U32Value(DataType):
 
     def _to_data_value(self, value):
         if self._is_valid_assign_type(value):
-            value = SystemUInt32(value)
+            value = SystemUInt32(int(value))
         else:
             raise TypeError('%s can not be created from value "%s"' % (self.__class__.__name__, str(value)))
         return ClientApiU32Value(value)
@@ -534,7 +539,7 @@ class U64Value(DataType):
 
     def _to_data_value(self, value):
         if self._is_valid_assign_type(value):
-            value = SystemUInt64(value)
+            value = SystemUInt64(int(value))
         else:
             raise TypeError('%s can not be created from value "%s"' % (self.__class__.__name__, str(value)))
         return ClientApiU64Value(value)

--- a/src/niveristand/clientapi/_stimulusprofilesession.py
+++ b/src/niveristand/clientapi/_stimulusprofilesession.py
@@ -52,7 +52,7 @@ class _StimulusProfileSession(_DotNetClassWrapperBase):
             str: The ID of the Stimulus profile session.
 
         """
-        ret_val, session_id, err = self._dot_net_instance.Deploy(auto_start, None, None)
+        session_id, err = self._dot_net_instance.Deploy(auto_start, None, None)
         err = _Error(err)
         if err.is_error:
             raise \

--- a/src/niveristand/clientapi/realtimesequencedefinition.py
+++ b/src/niveristand/clientapi/realtimesequencedefinition.py
@@ -1,4 +1,5 @@
 import os
+from NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi import ErrorAction
 from niveristand import _errormessages, errors
 from niveristand import _internal
 from niveristand._translation.py2rtseq.utils import _py_param_name_to_rtseq_param_name
@@ -95,7 +96,7 @@ def add_return_variable(rtseq, name, default_value):
 
 
 def add_generate_error(block, code, message, action):
-    block.AddStatement(GenerateError(code, message, action))
+    block.AddStatement(GenerateError(code, message, ErrorAction(action)))
 
 
 def add_stop_task(block, taskname):

--- a/src/niveristand/library/_tasks.py
+++ b/src/niveristand/library/_tasks.py
@@ -271,7 +271,7 @@ class _Scheduler(object):
         thread = current_thread()
         if thread in self._task_dict:
             raise errors.VeristandError(_errormessages.reregister_thread)
-        task = _Task(thread.getName())
+        task = _Task(thread.name)
         # queue the task
         self.register_task(task)
         # queue an iteration counter for this top-level task

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, flake8
+envlist = py37, py38, py39, flake8
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml
@@ -13,7 +13,7 @@ setenv = PYTHONPATH = {toxinidir}/tests
 passenv = vsdev.json
 deps =
     pytest
-    pythonnet
+    pythonnet~=3.0.1
     pyyaml
     numpy
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, flake8
+envlist = py37, py38, py39, py310, py311, flake8
 
 [testenv]
 commands = pytest --junitxml={envlogdir}/junit-{envname}.xml


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds support for pythonnet 3.0.1 and fixes issues identified by failing tests.
Fixes:
1. explicitly coerce str to double (0) where implicit conversion was done previously
2. explicitly convert to int before calling SystemInt32 on values
3. remove null return value from return tuples as they are no longer sent by pythonnet
4. explicitly coerce to Enum rather than relying on implicit conversion for ErrorAction
5. change deprecated getName() to name to avoid warnings in py310+

### Why should this Pull Request be merged?

pythonnet 3.0.1 is required to move to python 3.9.x+.

### What testing has been done?

Ran all of the unit tests, all passed:
![image](https://user-images.githubusercontent.com/42351034/214324000-4b3c6322-aa65-4547-bfec-9cd3df3920dd.png)

py10
![image](https://user-images.githubusercontent.com/42351034/214496250-e258832f-8116-427b-9514-a9d2b7b66c3a.png)

py11
![image](https://user-images.githubusercontent.com/42351034/214496210-c2657279-7aaf-4641-b931-a1fd51c4ed15.png)

