### PR TITLE
update all comments to use VeriStand, and add posargs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Setup module for NI Veristand."""
+"""Setup module for NI VeriStand."""
 from os.path import dirname
 from os.path import join
 from setuptools import find_packages

--- a/src/niveristand/_errormessages.py
+++ b/src/niveristand/_errormessages.py
@@ -1,4 +1,4 @@
-init_var_invalid_type = "Variables must be initialized with a valid Veristand datatype."
+init_var_invalid_type = "Variables must be initialized with a valid VeriStand datatype."
 invalid_nested_funcdef = "Nested function definitions are only allowed inside a multitask."
 invalid_top_level_func = "Invalid top level function."
 save_without_valid_sequence = "No valid real-time sequence to save."

--- a/src/niveristand/legacy/NIVeriStand.py
+++ b/src/niveristand/legacy/NIVeriStand.py
@@ -4,7 +4,7 @@ NI VeriStand Python API.
 @ Copyright 2009-2018 by National Instruments Corp.
 All righs reserved.
 
-C-Python code wrapper of NI Veristand client API.
+C-Python code wrapper of NI VeriStand client API.
 """
 
 import os

--- a/tests/legacy/README.md
+++ b/tests/legacy/README.md
@@ -1,5 +1,5 @@
 ## How to test the Legacy API with these tests:
 
-1. Install **Veristand 2020 R6** or older (newer versions will fail some of the tests because the models used in them were deprecated)
+1. Install **VeriStand 2020 R6** or older (newer versions will fail some of the tests because the models used in them were deprecated)
 2. call `pytest tests/legacy` on the `main` directory (or just `pytest` on the `tests/legacy` directory)
-3. Some of the tests open Veristand if not already opened, but other tests do not, so if you are running a subtest of the tests, you'll need to have Veristand running (but nothing should be deployed).
+3. Some of the tests open VeriStand if not already opened, but other tests do not, so if you are running a subtest of the tests, you'll need to have VeriStand running (but nothing should be deployed).

--- a/tests/legacy/test_legacy_model_manager2_api.py
+++ b/tests/legacy/test_legacy_model_manager2_api.py
@@ -9,7 +9,7 @@ from niveristand.legacy.NIVeriStand import NIVeriStandException
 #Every test should have a user variable that have a test ID number to ensure that you are running the correct test configuration.
 TEST_ID = 1122
 
-# This test requires Veristand 2020 or older due to the models
+# This test requires VeriStand 2020 or older due to the models
 def test_model_manager2_legacy():
     #Getting a handle to the workspace API
     #Other API: Model, Alarm, AlarmManager, SoftwareForcing, ModelManager

--- a/tests/legacy/test_legacy_model_manager_api.py
+++ b/tests/legacy/test_legacy_model_manager_api.py
@@ -10,7 +10,7 @@ from niveristand.legacy.NIVeriStand import NIVeriStandException
 TEST_ID = 1122
 
 
-# This test requires Veristand 2020 or older due to the models
+# This test requires VeriStand 2020 or older due to the models
 def test_model_manager_legacy():
     #Getting a handle to the workspace API
     #Other API: Model, Alarm, AlarmManager, SoftwareForcing, ModelManager

--- a/tests/legacy/test_legacy_reconnect_to_system.py
+++ b/tests/legacy/test_legacy_reconnect_to_system.py
@@ -4,7 +4,7 @@ import pytest
 from niveristand.legacy import NIVeriStand
 
 
-# This test requires Veristand 2020 or older due to the models
+# This test requires VeriStand 2020 or older due to the models
 def test_reconnect_to_system():
     system_definition = r"C:\Users\Public\Documents\National Instruments\NI VeriStand 2020\Projects\Example\Sinewave Delay.nivssdf"
     # connect to system with a separate instance of the workspace

--- a/tests/legacy/test_legacy_workspace2_api.py
+++ b/tests/legacy/test_legacy_workspace2_api.py
@@ -6,7 +6,7 @@ from niveristand.legacy.NIVeriStand import NIVeriStandException
 
 TEST_ID = 124123
 
-# This test requires Veristand 2020 or older due to the models
+# This test requires VeriStand 2020 or older due to the models
 def test_workspace2_api():
     workspace = NIVeriStand.Workspace2("localhost")
     print("")

--- a/tests/legacy/test_legacy_workspace_api.py
+++ b/tests/legacy/test_legacy_workspace_api.py
@@ -5,7 +5,7 @@ from niveristand.legacy import NIVeriStand
 from niveristand.legacy.NIVeriStand import NIVeriStandException
 
 
-# This test requires Veristand 2020 or older due to the models
+# This test requires VeriStand 2020 or older due to the models
 def test_workspace_api():
     TEST_ID = 124123
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py37, py38, py39, py310, py311, flake8
 
 [testenv]
-commands = pytest --junitxml={envlogdir}/junit-{envname}.xml
+commands = pytest --junitxml={envlogdir}/junit-{envname}.xml {posargs}
 setenv = PYTHONPATH = {toxinidir}/tests
     vsdev.yaml = {toxinidir}/tests/vsdev.yaml
 passenv = vsdev.json


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

1. update comments (trivial) to say VeriStand instead of Veristand.
2. add {posargs} to tox.ini to allow custom calls (for example, specifying the tests/legacy location, or testing a subset of all tests, using tox).

### Why should this Pull Request be merged?

trivial clean up and more flexibility to manually running ATS.

### What testing has been done?

just editing comments and adding the option for commands.