### PR TITLE
Fix import order

### DIFF
--- a/src/niveristand/__init__.py
+++ b/src/niveristand/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from niveristand import _internal  # loads the VeriStand .NET dlls for subsequence imports
+from niveristand import _internal  # noqa: F401: loads the .NET dlls for subsequent imports
 from niveristand._auto_generated_classes import ErrorCode, VeriStandSdfError, XMLVersionInfo
 from niveristand._decorators import nivs_rt_sequence, NivsParam
 from niveristand.realtimesequencetools import run_py_as_rtseq, save_py_as_rtseq

--- a/src/niveristand/__init__.py
+++ b/src/niveristand/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from niveristand import _internal  # loads the VeriStand .NET dlls for subsequence imports
 from niveristand._auto_generated_classes import ErrorCode, VeriStandSdfError, XMLVersionInfo
 from niveristand._decorators import nivs_rt_sequence, NivsParam
 from niveristand.realtimesequencetools import run_py_as_rtseq, save_py_as_rtseq

--- a/src/niveristand/__init__.py
+++ b/src/niveristand/__init__.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+from niveristand._auto_generated_classes import ErrorCode, VeriStandSdfError, XMLVersionInfo
 from niveristand._decorators import nivs_rt_sequence, NivsParam
 from niveristand.realtimesequencetools import run_py_as_rtseq, save_py_as_rtseq
-from niveristand._auto_generated_classes import ErrorCode, VeriStandSdfError, XMLVersionInfo
 
 __all__ = [
     "ErrorCode",


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This fixes the order of imports in `src/niveristand/__init__.py`, which was causing a flake8 error. At the same time, reordering required an explicit call import of niveristand._internal, which loads the VeriStand .NET dlls required by the _auto_generated_classes import (and imported implicitly by _decorators)

This was missed on the previous pull request because of the last-minute addition of the `niveristand` prefix to the `auto_generated_classes` import - I ran Python 3.8 tests again but not flake8.

### Why should this Pull Request be merged?

Fixes flake8 error.

### What testing has been done?

Ran flake8 and py38 tests.