### PR TITLE
Remove outdated __futures__ declarations

### DIFF
--- a/src/niveristand/__init__.py
+++ b/src/niveristand/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 from niveristand import _internal  # noqa: F401: loads the .NET dlls for subsequent imports
 from niveristand._auto_generated_classes import ErrorCode, VeriStandSdfError, XMLVersionInfo
 from niveristand._decorators import nivs_rt_sequence, NivsParam

--- a/src/niveristand/_translation/py2rtseq/__init__.py
+++ b/src/niveristand/_translation/py2rtseq/__init__.py
@@ -1,4 +1,0 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

We have a number of `from __futures__ import X` declarations that were added for Python 2 optional features but aren't relevant in python 3 now that those features in the language. From the table in https://docs.python.org/3/library/__future__.html:

feature | mandatory in (Python version)
-- | --
absolute_import | 3.0
division | 3.0
print_function| 3.0
unicode_literals | 3.0

### What does this Pull Request accomplish?

Remove unnecessary code lingering from Python 2.

### Why should this Pull Request be merged?

Because this reduces legacy code.

### What testing has been done?

Ran py38 test and flake8 linter.