### PR TITLE
Fix linting error for type checks

### DIFF
--- a/examples/sysdef_example.py
+++ b/examples/sysdef_example.py
@@ -70,7 +70,7 @@ def main(filepath=None):
 
         save_system_definition(system_definition)
     except BaseException as e:
-        if type(e) == type(VeriStandSdfError):
+        if isinstance(e, VeriStandSdfError):
             print(f"\nVeriStandSdfError: {str(e)}", end="")
         elif str(type(e)) == "<class 'NationalInstruments.VeriStand.VeriStandException'>":
             # VeriStandSdfError gives better error messages


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Check types using `isinstance` instead of `type(a) == type(b)`.

### Why should this Pull Request be merged?

Fixes ASW release failure [AB#2474100](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2474100).

### What testing has been done?

None
