### PR TITLE
Fixing two method overloads

### DIFF
--- a/examples/sysdef_example.py
+++ b/examples/sysdef_example.py
@@ -52,7 +52,7 @@ def main(filepath=None):
     try:
         print("Creating System Definition...")
         if not filepath:
-            filepath = os.path.join(__file__, "..", "combined.nivssdf")
+            filepath = os.path.join(os.path.dirname(__file__), "combined.nivssdf")
         system_definition = create_system_definition(filepath)
 
         print("Adding and populating DAQ Devices... ")

--- a/src/niveristand/systemdefinitionapi/_auto_generated_classes.py
+++ b/src/niveristand/systemdefinitionapi/_auto_generated_classes.py
@@ -4866,7 +4866,7 @@ class SystemDefinition(_DotNetBase):
         ...
 
     def save_system_definition_file(self, *args):
-        unwrapped = _unwrap(None, *args)
+        unwrapped = _unwrap({(str,): (1, ""), (): (0, "")}, *args)
         dotnet_result = self._dotnet_instance.SaveSystemDefinitionFile(*unwrapped)
         return _wrap(dotnet_result)
 

--- a/src/niveristand/systemstorage/_auto_generated_classes.py
+++ b/src/niveristand/systemstorage/_auto_generated_classes.py
@@ -1483,7 +1483,7 @@ class DocumentType(_DotNetBase):
         ...
 
     def save_system_storage_file(self, *args):
-        unwrapped = _unwrap(None, *args)
+        unwrapped = _unwrap({(): (0, ""), (str,): (1, "")}, *args)
         dotnet_result = self._dotnet_instance.SaveSystemStorageFile(*unwrapped)
         return _wrap(dotnet_result)
 

--- a/tests/sdf_api/test_sdf_api__overloads__save_sdf.py
+++ b/tests/sdf_api/test_sdf_api__overloads__save_sdf.py
@@ -1,0 +1,49 @@
+"""Tests the generated python code for method overload resolution."""
+import os
+
+import pytest
+from niveristand.systemdefinitionapi import (  # noqa: I100, E402
+    SystemDefinition,
+)
+
+
+def test_save_system_definition_file_same_filename():
+    "Runs the test described in the title."
+    try:
+        sdf_path = os.path.join(os.path.dirname(__file__), "test-original.nivssdf")
+        if os.path.exists(sdf_path):
+            os.remove(sdf_path)
+
+        sdf = SystemDefinition("name", "", "", "", "", "Windows", sdf_path)
+
+        assert not os.path.exists(sdf_path)
+        sdf.save_system_definition_file()
+        assert os.path.exists(sdf_path)
+    except Exception as e:
+        if type(e).__name__ == "DllNotFoundException":
+            pytest.skip("VeriStand installation or vsdev required for NIVeriStand_util.dll")
+        else:
+            raise
+
+
+# AB#2583012: save_system_definition_file is not respecting file path argument
+def test_save_system_definition_file_different_filename():
+    "Runs the test described in the title."
+    try:
+        original_sdf_path = os.path.join(os.path.dirname(__file__), "test-original.nivssdf")
+        alternate_sdf_path = os.path.join(os.path.dirname(__file__), "test-alternate.nivssdf")
+        if os.path.exists(original_sdf_path):
+            os.remove(original_sdf_path)
+        if os.path.exists(alternate_sdf_path):
+            os.remove(alternate_sdf_path)
+
+        sdf = SystemDefinition("name", "", "", "", "", "Windows", original_sdf_path)
+
+        sdf.save_system_definition_file(alternate_sdf_path)
+        assert os.path.exists(alternate_sdf_path)
+        assert not os.path.exists(original_sdf_path)
+    except Exception as e:
+        if type(e).__name__ == "DllNotFoundException":
+            pytest.skip("VeriStand installation or vsdev required for NIVeriStand_util.dll")
+        else:
+            raise


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
It fixes a couple methods that weren't being disambiguated from their other overloads - `save_system_definition_file` in particular, but also `save_system_storage_file`.

More minorly, but unrelated, it improves the readability of how sysdef_example.py gets the path to the nivssdf file it creates.

### Why should this Pull Request be merged?
This fixes [AB#2583012](https://dev.azure.com/ni/DevCentral/_workitems/edit/2583012).

### What testing has been done?
Ran flake8 and py39 tests.