### PR TITLE
add readthedocs.yaml, remove magic mock and old dependency locks

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,16 +174,16 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-# MOCK_MODULES = [
-#     "clr",
-#     "System",
-#     "System.IO",
-#     "NationalInstruments",
-#     "NationalInstruments.VeriStand",
-#     "NationalInstruments.VeriStand.ClientAPI",
-#     "NationalInstruments.VeriStand.Data",
-#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
-#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
-#     "niveristand.clientapi._datatypes.rtprimitives",
-# ]
-# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+MOCK_MODULES = [
+    "clr",
+    "System",
+    "System.IO",
+    "NationalInstruments",
+    "NationalInstruments.VeriStand",
+    "NationalInstruments.VeriStand.ClientAPI",
+    "NationalInstruments.VeriStand.Data",
+    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
+    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
+    "niveristand.clientapi._datatypes.rtprimitives",
+]
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 #
 import os
 import sys
-from unittest.mock import Mock
 
 sys.path.insert(0, os.path.abspath("../src"))
 
@@ -167,7 +166,7 @@ texinfo_documents = [
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-MOCK_MODULES = [
+autodoc_mock_imports = [
     "clr",
     "System",
     "System.IO",
@@ -179,4 +178,3 @@ MOCK_MODULES = [
     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
     "niveristand.clientapi._datatypes.rtprimitives",
 ]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,16 +174,16 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = [
-    "clr",
-    "System",
-    "System.IO",
-    "NationalInstruments",
-    "NationalInstruments.VeriStand",
-    "NationalInstruments.VeriStand.ClientAPI",
-    "NationalInstruments.VeriStand.Data",
-    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
-    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
-    "niveristand.clientapi._datatypes.rtprimitives",
-]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+# MOCK_MODULES = [
+#     "clr",
+#     "System",
+#     "System.IO",
+#     "NationalInstruments",
+#     "NationalInstruments.VeriStand",
+#     "NationalInstruments.VeriStand.ClientAPI",
+#     "NationalInstruments.VeriStand.Data",
+#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
+#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
+#     "niveristand.clientapi._datatypes.rtprimitives",
+# ]
+# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 # -- Project information -----------------------------------------------------
 
 project = "niveristand-python"
-copyright = datetime.datetime.now().year + ", National Instruments"
+copyright = str(datetime.datetime.now().year) + ", National Instruments"
 author = "National Instruments"
 
 # The short X.Y version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 #
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 sys.path.insert(0, os.path.abspath("../src"))
 
@@ -167,23 +167,16 @@ texinfo_documents = [
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-# MOCK_MODULES = [
-#     "clr",
-#     "System",
-#     "System.IO",
-#     "NationalInstruments",
-#     "NationalInstruments.VeriStand",
-#     "NationalInstruments.VeriStand.ClientAPI",
-#     "NationalInstruments.VeriStand.Data",
-#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
-#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
-#     "niveristand.clientapi._datatypes.rtprimitives",
-# ]
-# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+MOCK_MODULES = [
+    "clr",
+    "System",
+    "System.IO",
+    "NationalInstruments",
+    "NationalInstruments.VeriStand",
+    "NationalInstruments.VeriStand.ClientAPI",
+    "NationalInstruments.VeriStand.Data",
+    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
+    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
+    "niveristand.clientapi._datatypes.rtprimitives",
+]
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -89,7 +89,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -174,16 +174,16 @@ class Mock(MagicMock):
         return MagicMock()
 
 
-MOCK_MODULES = [
-    "clr",
-    "System",
-    "System.IO",
-    "NationalInstruments",
-    "NationalInstruments.VeriStand",
-    "NationalInstruments.VeriStand.ClientAPI",
-    "NationalInstruments.VeriStand.Data",
-    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
-    "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
-    "niveristand.clientapi._datatypes.rtprimitives",
-]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+# MOCK_MODULES = [
+#     "clr",
+#     "System",
+#     "System.IO",
+#     "NationalInstruments",
+#     "NationalInstruments.VeriStand",
+#     "NationalInstruments.VeriStand.ClientAPI",
+#     "NationalInstruments.VeriStand.Data",
+#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi",
+#     "NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities",
+#     "niveristand.clientapi._datatypes.rtprimitives",
+# ]
+# sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 
@@ -20,7 +21,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 # -- Project information -----------------------------------------------------
 
 project = "niveristand-python"
-copyright = "2018, National Instruments"
+copyright = datetime.datetime.now().year + ", National Instruments"
 author = "National Instruments"
 
 # The short X.Y version

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,3 @@
 pyyaml
 rinohtype
 sphinx_rtd_theme
-# rinohtype 0.5.3 does not work with importlib-metadata>=4.3.0 (https://www.higithub.com/brechtm/issue/rinohtype/285)
-importlib-metadata==4.8.0
-sphinx==6.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,5 @@ pyyaml
 rinohtype
 sphinx_rtd_theme
 # rinohtype 0.5.3 does not work with importlib-metadata>=4.3.0 (https://www.higithub.com/brechtm/issue/rinohtype/285)
-importlib-metadata==4.2.0
+importlib-metadata==4.8.0
+sphinx==6.2.1


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

[In this blog post](https://blog.readthedocs.com/defaulting-latest-build-tools/) ReadTheDocs announced that they were no longer installing an old, consistent version of sphinx, and they would now be using the latest as the default.  The latest sphinx does not handle Magic Mock well and additionally the readthedocs.yaml defined [here](https://docs.readthedocs.io/en/stable/config-file/v2.html) is now required.  This PR removes the former and adds the latter.

### Why should this Pull Request be merged?

ReadTheDocs is currently not building the documentation from this repo (has been failing since September), and it has not been correctly building some of the sections for several years now.  This not only gets the builds back up and running but allows some sections of the API library to generate correctly now as shown below:
niveristand-python 1.0.0 -> 3.0.0 all had the issue below
![image](https://github.com/ni/niveristand-python/assets/42351034/ce447733-7c65-4417-aa04-b842f5c59c93)

vs this PR
![image](https://github.com/ni/niveristand-python/assets/42351034/77a81548-6cc1-499a-86db-74750356841a)


### What testing has been done?

Built locally with `tox -e docs -r` and browsed the documentation that was output locally, and checked a build on readthedocs as well https://niveristand-python.readthedocs.io/en/dev-specify-sphinx/index.html.  Note that this URL may stop working after the PR is merged.
