### PR TITLE
Defined target while calling run_rt_sequence API

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ author = "National Instruments"
 # The short X.Y version
 version = "3.2"
 # The full version, including alpha/beta/rc tags
-release = "3.2.2"
+release = "3.2.3"
 
 # -- General configuration ---------------------------------------------------
 

--- a/examples/engine_demo/engine_demo_advanced.py
+++ b/examples/engine_demo/engine_demo_advanced.py
@@ -77,7 +77,7 @@ def run_engine_demo_advanced():
 
 
 def run_deterministic():
-    return run_py_as_rtseq(run_engine_demo_advanced)
+    return run_py_as_rtseq(run_engine_demo_advanced, target=None)
 
 
 def run_non_deterministic():

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def get_version(name):
     script_dir = os.path.dirname(os.path.realpath(__file__))
     script_dir = os.path.join(script_dir, name)
     if not os.path.exists(os.path.join(script_dir, 'VERSION')):
-        version = '3.2.2'
+        version = '3.2.3'
     else:
         with open(os.path.join(script_dir, "VERSION"), "r") as version_file:
             version = version_file.read().rstrip()

--- a/src/niveristand/clientapi/realtimesequence.py
+++ b/src/niveristand/clientapi/realtimesequence.py
@@ -37,12 +37,13 @@ class RealTimeSequence:
 
     """
 
-    def __init__(self, top_level_func, rtseq_pkg=None):
+    def __init__(self, top_level_func, rtseq_pkg=None, target=None):
         self._top_level_func = top_level_func
         self._path = ""
         self._rtseq = None
         self._rtseqpkg = rtseq_pkg
         self._ref = list()
+        self.target = target
         # finally, initialize the transform
         self._transform()
 
@@ -69,7 +70,7 @@ class RealTimeSequence:
             raise VeristandError(_errormessages.invalid_path_for_sequence)
 
         name = self._build_file_name()
-        return rtseqapi.run_rt_sequence(name, rtseq_params)
+        return rtseqapi.run_rt_sequence(name, rtseq_params, target = self.target)
 
     def save(self, path=None):
         """

--- a/src/niveristand/clientapi/realtimesequence.py
+++ b/src/niveristand/clientapi/realtimesequence.py
@@ -30,6 +30,8 @@ class RealTimeSequence:
         top_level_func: the function to transform.
         rtseq_pkg(:class:`RealTimeSequencePackage`): the containing package in case you want to add this sequence to a
                                                     library.
+        target: The name of the target on which to deploy or run the real-time sequence. 
+         If None, the default target is used.
 
     Raises:
         :class:`niveristand.errors.TranslateError`: if translation fails.

--- a/src/niveristand/clientapi/realtimesequencedefinition.py
+++ b/src/niveristand/clientapi/realtimesequencedefinition.py
@@ -137,7 +137,7 @@ def _get_channel_node_info(name, node_info_list):
     raise errors.VeristandError(_errormessages.channel_not_found % name)
 
 
-def run_rt_sequence(rt_sequence_path, rtseq_params):
+def run_rt_sequence(rt_sequence_path, rtseq_params, target = None):
     rtseq_params = [
         _SequenceParameterAssignmentInfoFactory.create(
             _py_param_name_to_rtseq_param_name(key), rtseq_params[key]
@@ -145,7 +145,7 @@ def run_rt_sequence(rt_sequence_path, rtseq_params):
         for key in rtseq_params
     ]
     seq_call_info = _SequenceCallInfoFactory.create(
-        rt_sequence_path, None, rtseq_params, False, 100000
+        rt_sequence_path, target, rtseq_params, False, 100000
     )
     session = _DefaultGatewayFactory.get_new_stimulus_profile_session(
         rt_sequence_path, [seq_call_info], ""

--- a/src/niveristand/realtimesequencetools.py
+++ b/src/niveristand/realtimesequencetools.py
@@ -9,6 +9,8 @@ def run_py_as_rtseq(toplevelfunc, rtseq_params={}, target=None):
         toplevelfunc: the Python function to run.
         rtseq_params (Dict[str, niveristand.clientapi._datatypes.rtprimitives.DoubleValue]):  the parameters to be
          passed to the RT sequence.
+        target: The name of the target on which to deploy or run the real-time sequence. 
+         If None, the default target is used.
 
     Returns:
         Union[float, None]:

--- a/src/niveristand/realtimesequencetools.py
+++ b/src/niveristand/realtimesequencetools.py
@@ -1,7 +1,7 @@
 from niveristand.errors import RunError, VeristandNotImplementedError
 
 
-def run_py_as_rtseq(toplevelfunc, rtseq_params={}):
+def run_py_as_rtseq(toplevelfunc, rtseq_params={}, target=None):
     """
     Runs a Python function as an RT sequence in the VeriStand Engine.
 
@@ -22,7 +22,7 @@ def run_py_as_rtseq(toplevelfunc, rtseq_params={}):
     """
     from niveristand.clientapi import RealTimeSequence
 
-    seq = RealTimeSequence(toplevelfunc)
+    seq = RealTimeSequence(toplevelfunc, target = target)
     result_state = seq.run(rtseq_params)
     result_state.wait_for_result()
     result_state.session.undeploy()


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
In veriStand python APIs, run_rt_sequence/run_py_as_rtseq does not provide the option to configure the target. It defaults the target value to empty internally resulting in choosing the default target.
Modified the python API for allowing to define target when calling the function run_py_as_rtseq.

### Why should this Pull Request be merged?
[Bug 3218836](https://dev.azure.com/ni/DevCentral/_workitems/edit/3218836): VeriStand Run RT Sequence Python API does not provide the option to specify the target

### Testing
<img width="899" height="96" alt="image" src="https://github.com/user-attachments/assets/e2f60ae9-2078-4c3e-97a8-cf81f9424daf" />
Tested by running the 'run_py_as_rtseq' function with target parameter in Engine Demo Advanced example with an RT Target.
The script was running successfully with the target deployed.
